### PR TITLE
Update viewport meta tag and input field autocomplete

### DIFF
--- a/apps/landlord-portal/index.html
+++ b/apps/landlord-portal/index.html
@@ -5,14 +5,14 @@
 		<link rel="icon" href="/favicon.ico" />
 		<link rel="apple-touch-icon" sizes="180X180" href="/ios-180.png" />
 		<meta http-equiv="x-ua-compatible" content="IE=edge" />
-		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<meta name="viewport" content="width=device-width, initial-scale=0.9 user-scalable=no" />
 		<meta http-equiv="ScreenOrientation" content="autoRotate:disabled" />
 		<meta name="theme-color" content="#002147" />
 		<link rel="manifest" href="/site.webmanifest" />
 		<link rel="preconnect" href="https://fonts.googleapis.com" />
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 		<!-- iOS Splash screen settings -->
-		<meta name="mobile-web-app-capable" content="yes">
+		<meta name="apple-mobile-web-app-capable" content="yes">
 		<meta name="apple-mobile-web-app-status-bar-style" content="black">
 		<!-- iOS Splash Screen images -->
 		<link rel="apple-touch-startup-image"

--- a/apps/landlord-portal/src/components/ControlledComponents/OTPInputField.tsx
+++ b/apps/landlord-portal/src/components/ControlledComponents/OTPInputField.tsx
@@ -187,6 +187,7 @@ const OTPInput: React.FC<OTPTextInput> = ({
 									onPaste: (event) => handlePaste(event, index),
 									onKeyPress: (event) => handleKeyPress(event),
 									value: value[index] ?? '',
+									autoComplete: 'one-time-code',
 								},
 							}}
 						/>

--- a/apps/landlord-portal/src/pages/Login/index.tsx
+++ b/apps/landlord-portal/src/pages/Login/index.tsx
@@ -248,7 +248,7 @@ const Login = () => {
 										name='email'
 										label='Email'
 										type='email'
-										autoComplete='email'
+										autoComplete='username'
 										placeholder='Enter your email address'
 										formik={formik}
 										inputProps={{


### PR DESCRIPTION
- Update the viewport meta tag in the index.html file to set the initial scale to 0.9 and disable user scaling.
- Add the 'autoComplete' attribute with the value 'one-time-code' to the OTPInputField component in OTPInput.tsx.
- Change the 'autoComplete' attribute value from 'email' to 'username' in the Login component in index.tsx.